### PR TITLE
Add function to get latest tag (even non-release/stable)

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -180,10 +180,14 @@ This variable contains the name of the recipe being run.
 `B_GITVER <git repostiory> [filter]`
 
 This function attempts to remotely find the newest tag for a git repository. It filters
-out some commonly used tags that indicate non-release tags. 
+out some commonly used tags that indicate non-release tags.
 Optionally a filter option can be giving which will be used to filter out any other
 tags that should not be used.
 The function return the newest tag it can find.
+
+`B_GITVER_LATEST <git repository> [filter]`
+
+This function does the same as B_GITVER, except that it will get the highest version possible, even if that version is a beta, rc or otherwise not stable.
 
 `B_GITHUBVER <github repository>`
 

--- a/build
+++ b/build
@@ -459,7 +459,7 @@ version_get() {
    B_HGREV() {
       hg id $1
    }
-   export -f B_GITVER B_GITHUBVER B_SVNDATE B_SVNREV B_HGREV
+   export -f B_GITVER_LATEST B_GITVER B_GITHUBVER B_SVNDATE B_SVNREV B_HGREV
    CMD=$( recipe_section_get $pkg VERSION )
    test $? -ne 0 && { output $CMD ; return 1; }
    local ver=$( bash $DEBUG -e -c "$CMD" 2>/dev/null )

--- a/build
+++ b/build
@@ -437,6 +437,10 @@ version_get() {
 
    export B_SARCH
    export B_NAME=$1
+   B_GITVER_LATEST() {
+      exp=""
+      test "$2" != "" && exp="-e $2"
+      git ls-remote --tags $1 | grep -v '{}' | cut -d '/' -f 3  | sed "s/^v//" | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | tail -1
    B_GITVER() {
       exp=""
       test "$2" != "" && exp="-e $2"

--- a/build
+++ b/build
@@ -441,6 +441,7 @@ version_get() {
       exp=""
       test "$2" != "" && exp="-e $2"
       git ls-remote --tags $1 | grep -v '{}' | cut -d '/' -f 3  | sed "s/^v//" | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | tail -1
+   }
    B_GITVER() {
       exp=""
       test "$2" != "" && exp="-e $2"


### PR DESCRIPTION
This PR adds the B_GITVER_LATEST fetch method, it will grab the latest version from the specified git repository, without filtering away any tags that could be non-stable.