### PR TITLE
This commit makes the B_GITVER check case-insensitive

### DIFF
--- a/build
+++ b/build
@@ -463,7 +463,7 @@ version_get() {
          shift
       fi
       test "$2" != "" && exp="$exp -e $2"
-      test "$exp" != "" && exp="grep -v $exp" || exp="cat"
+      test "$exp" != "" && exp="grep -iv $exp" || exp="cat"
       git ls-remote --tags $1 | grep -v '{}' | cut -d '/' -f 3  | sed "s/^v//" | $exp | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n | tail -1
    }
    B_GITHUBVER() {


### PR DESCRIPTION
I noticed it when building a package that used capitals to designate RC releases.