### PR TITLE
Reworked GITLABVER and GITHUBVER to use the API of each platform

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -239,19 +239,28 @@ The command has options to process the raw output and mold it into something use
 
 The function return the newest tag it can find.
 
-`B_GITHUBVER <github repository>`
+`B_GITHUBVER <github repository uri> <branch>`
 
 This function attempts to find the last date an update was done on a repository on
 github. For projects not using tags, this allow for builds to be created on a date
 stamp.
-The function returns the newest date it can find.
+The function returns the newest date it can find. When <branch> is not supplied, it will look in master.
 
-`B_GITLABVER <gitlab repository>`
+Github's core API is rate-limited to 60 requests per hour, as of now there is no way to increase it.
+
+Example: `B_GITHUBVER username/reponame my_first_branch`
+
+`B_GITLABVER <gitlab repository uri or id> <branch>`
 
 This function attempts to find the last date an update was done on a repository on
 gitlab. For projects not using tags, this allow for builds to be created on a date
 stamp.
-The function returns the newest date it can find.
+The function returns the newest date it can find. When <branch> is not supplied, it will look in master.
+
+Gitlab's API requires uri's to be URL-encoded or you can use the project ID.
+
+Example: `B_GITHUBVER username%2Freponame my_first_branch`
+         `B_GITHUBVER 1 my_first_branch`
 
 `B_SVNDATE <svn repository>`
 

--- a/build
+++ b/build
@@ -621,10 +621,12 @@ version_get() {
       bash -c "$CMD"
    }
    B_GITLABVER() {
-      wget -q -O - "$1/commits/master" | grep -e "commit-header js-commit-header" | cut -d'"' -f 4 | sed "s/-//g" | head -n 1
+       BRANCH=$2
+       curl -sS https://gitlab.com/api/v4/projects/$1/repository/commits?ref_name=${BRANCH:=master} | jq '.[0].committed_date[0:10] | gsub("-";"")'
    }
    B_GITHUBVER() {
-      wget -q -O - $1 | sed '/time-ago datetime=/!d; s/.*time-ago datetime="[TZ\:0-9\-]*">\([^<]*\)<.*/\1/' | while read line; do date --date="$line" "+%Y%m%d"; done | sort | tail -1
+      BRANCH=$2
+      curl -sS https://api.github.com/repos/$1/commits/${BRANCH:=master} | jq -cr '.commit.committer.date[0:10] | gsub("-";"")'
    }
    B_SVNDATE() {
       date -d "$(svn info --non-interactive --trust-server-cert $1 | grep 'Last Changed Date:' | cut -d':' -f2-)" "+%Y%m%d"

--- a/build
+++ b/build
@@ -49,10 +49,10 @@ usage() {
 require_software() {
    case "$OS" in
    "Debian GNU/Linux")
-      echo gawk grep git svn wget fakeroot bzip2 hg lsb_release
+      echo gawk grep git svn wget fakeroot bzip2 hg lsb_release jq
    ;;
    "CentOS Linux")
-      echo gawk grep git svn wget bzip2 hg
+      echo gawk grep git svn wget bzip2 hg jq
    ;;
    esac
    exit 1

--- a/example-recipes/build.recipe
+++ b/example-recipes/build.recipe
@@ -20,6 +20,7 @@ torepo=y
 Package: build
 Version: B_VERSION
 Section: nbu
+Depends: jq
 Priority: optional
 Architecture: all
 Maintainer: mark@verboom.net


### PR DESCRIPTION
The title explains it all :)

This requires JQ to be installed to function!

I have also looked in working around Github's API rate limit, but the specific API endpoint does not allow larger quota's. The current limit is 60 requests / hour. Gitlab does not have a rate limit (from what I have noticed)

You can check your current remaining quota on: https://api.github.com/rate_limit