### PR TITLE
Minor fixes

### DIFF
--- a/build
+++ b/build
@@ -612,7 +612,7 @@ package_deb() {
          return 1
       else
          file="$pkgdir/*.deb"
-         cp "$file" "$PKGDIR"
+         cp $file "$PKGDIR"
          pkgfile=$(basename "$DESTDIR/$B_ARCH/${P_PKGDIR}"/*.deb)
       fi
    fi

--- a/build
+++ b/build
@@ -983,7 +983,7 @@ main() {
    if test $DO_CHECK -ne 0; then
       # Get current version and check if already built
       for i in "${!work_recipes[@]}"; do
-         B_ARCH=${work_arch[${work_recipes[$i]}]}
+         export B_ARCH=${work_arch[${work_recipes[$i]}]}
          work_version[$i]=$( check_version_built "${work_recipes[$i]}" "${work_version[$i]}")
          work_built[$i]=$?
          if test $DO_CHECK -eq 1 -o $DO_BUILD -eq 1 -a $B_FORCE -eq 0; then


### PR DESCRIPTION
Exporting B_ARCH in the check version command allows for recipes to use B_ARCH in the scripts they run to retrieve new versions.

Also fixed the copy function when pkgready=y, globbing does not work inside quotes.